### PR TITLE
Fix doc tradeoff comp run

### DIFF
--- a/doc/optimizations.txt
+++ b/doc/optimizations.txt
@@ -26,43 +26,57 @@ For an even faster run-time, we could disable assertions (which could be time co
 
     This list is partial.
 
-    The print_summary method allows several OpDBs and optimizers to list the executed optimizations.
-    This makes it possible to have an up-to-date list.
+    The print_summary method allows several OpDBs and optimizers to list the
+    executed optimizations.  This makes it possible to have an up-to-date list.
 
-    python -c "import theano; theano.compile.optdb.query(theano.compile.predefined_optimizers['<OPT_ID>']).print_summary()"
-    where <OPT_ID> can be one of o1, o2, o3, o4, unsafe.
-    o1 can also be written as fast_compile, and o4 can also be written as fast_run (see Table below).
+    .. code-block:: bash
 
-========================================================= ============= === === ================= ============= ======
-Optimization                                              o4 (fast_run) o3  o2  o1 (fast_compile) Stabilization unsafe  
-========================================================= ============= === === ================= ============= ======
-:term:`merge`                                             x             x   x    x                              x   
-:term:`constant folding<constant folding>`                x             x   x    x                              x   
-:term:`GPU transfer`                                      x             x   x    x                              x   
-:term:`shape promotion<shape promotion>`                  x             x                                       x
-:term:`fill cut<fill cut>`                                x             x                                       x
-:term:`inc_subtensor srlz.<inc_subtensor serialization>`  x             x                                       x
-:term:`reshape_chain`                                     x             x                                       x
-:term:`const. elimination<constant elimination>`          x             x                                       x
-:term:`add canonical. <add canonicalization>`             x             x                                       x
-:term:`mul canonical. <mul canonicalization>`             x             x                                       x
-:term:`dot22`                                             x             x                                       x
-:term:`sparse_dot`                                        x             x                                       x
-:term:`sum_scalar_mul`                                    x             x                                       x
-:term:`neg_neg`                                           x             x                                       x
-:term:`neg_div_neg`                                       x             x                                       x
-:term:`add specialize <add specialization>`               x             x                                       x
-:term:`mul specialize <mul specialization>`               x             x                                       x
-:term:`pow specialize <pow specialization>`               x             x                                       x
-:term:`inplace_setsubtensor`                              x                                                     
-:term:`gemm`                                              x             x                                       x
-:term:`inplace_elemwise`                                  x                                                         
-:term:`inplace_random`                                    x                                                     
-:term:`elemwise fusion`                                   x             x   x                                   x   
-:term:`local_log_softmax`                                 x             x                         x             x   
-:term:`local_remove_all_assert`                                                                                 x
-========================================================= ============= === === ================= ============= ======
+        python -c "import theano; theano.compile.optdb.query(theano.compile.predefined_optimizers['<OPT_ID>']).print_summary()"
 
+    where <OPT_ID> can be one of o1 (:ref:`† <o1=>`), o2, o3, o4 (:ref:`* <o4=>`), 
+    Stabilization or unsafe.
+
+
+========================================================= ============== === === ================= ============= ======
+Optimization                                              o4             o3  o2  o1                Stabilization unsafe  
+                                                          :ref:`* <o4=>`         :ref:`† <o1=>` 
+========================================================= ============== === === ================= ============= ======
+:term:`merge`                                             x              x   x    x                              x   
+:term:`constant folding<constant folding>`                x              x   x    x                              x   
+:term:`GPU transfer`                                      x              x   x    x                              x   
+:term:`shape promotion<shape promotion>`                  x              x                                       x
+:term:`fill cut<fill cut>`                                x              x                                       x
+:term:`inc_subtensor srlz.<inc_subtensor serialization>`  x              x                                       x
+:term:`reshape_chain`                                     x              x                                       x
+:term:`const. elimination<constant elimination>`          x              x                                       x
+:term:`add canonical. <add canonicalization>`             x              x                                       x
+:term:`mul canonical. <mul canonicalization>`             x              x                                       x
+:term:`dot22`                                             x              x                                       x
+:term:`sparse_dot`                                        x              x                                       x
+:term:`sum_scalar_mul`                                    x              x                                       x
+:term:`neg_neg`                                           x              x                                       x
+:term:`neg_div_neg`                                       x              x                                       x
+:term:`add specialize <add specialization>`               x              x                                       x
+:term:`mul specialize <mul specialization>`               x              x                                       x
+:term:`pow specialize <pow specialization>`               x              x                                       x
+:term:`inplace_setsubtensor`                              x                                                      
+:term:`gemm`                                              x              x                                       x
+:term:`inplace_elemwise`                                  x                                                          
+:term:`inplace_random`                                    x                                                      
+:term:`elemwise fusion`                                   x              x   x                                   x   
+:term:`local_log_softmax`                                 x              x                         x             x   
+:term:`local_remove_all_assert`                                                                                  x
+========================================================= ============== === === ================= ============= ======
+
+..  note::
+
+    .. _o4=:
+
+    \*) o4 is equivalent to fast_run
+
+    .. _o1=:
+
+    †) o1 is equivalent to fast_compile
 
 .. glossary::
 

--- a/doc/tutorial/modes.txt
+++ b/doc/tutorial/modes.txt
@@ -215,13 +215,13 @@ or per call to theano functions with ``theano.function(...mode=theano.Mode(optim
 =================  ============  ==============  ==================================================
 optimizer          Compile time  Execution time  Description
 =================  ============  ==============  ==================================================
-None               "++"          "++++++"        Applies none of Theano's opts
-o4 (fast_run)      "+++"         "+++++"         Applies all opts
-o3                 "++++"        "++++"          Applies all opts except ones that compile slower
-o2                 "+++++"       "+++"           Applies few basic opts and some that compile fast
-o1 (fast_compile)  "++++++"      "++"            Applies only basic opts
-stabilize          "+++++++"     "+"             Only applies stability opts
-unsafe             "+"           "+++++++"       Applies all opts, and removes safety checks
+None               "++++++"      "+"             Applies none of Theano's opts
+o1 (fast_compile)  "+++++"       "++"            Applies only basic opts
+o2                 "++++"        "+++"           Applies few basic opts and some that compile fast
+o3                 "+++"         "++++"          Applies all opts except ones that compile slower
+o4 (fast_run)      "++"          "+++++"         Applies all opts
+unsafe             "+"           "++++++"        Applies all opts, and removes safety checks
+stabilize          "+++++"       "++"            Only applies stability opts
 =================  ============  ==============  ==================================================
 
 For a detailed list of the specific optimizations applied for each of these


### PR DESCRIPTION
1. Improve optimizations doc visually
    - The bash code snippet was wrapping and hard to read.
    - table was exceeding the page's width.
2. Fix optimizer compile time in doc/tutorial/modes
    - `None` compile time was described as extensive while it's actually the
shortest one.